### PR TITLE
rewriting part of the readme to reflect correct connector names

### DIFF
--- a/max7219-breakout-system/README.md
+++ b/max7219-breakout-system/README.md
@@ -1,40 +1,50 @@
 # MobiFlight MAX7219 Breakout System
-The MobiFlight MAX7219 Breakout System board is slightly larger than the display PCBs at 80.0 x 66.0 mm.
+The MobiFlight MAX7219 Breakout System is a 80x80mm module with 4 driver chips, capable of driving 8 digits each.
 
-Since very few can get by with a MAX chip, this PCB is designed in such a way that it can accommodate up to 4 MAX chips. These chips are already connected in a daisy chain on the PCB. So no one has to worry about where the input or output is, just plug in the IN connector from the Arduino and the 4 MAX chips are connected to each other.
+These chips are already connected in a daisy chain on the PCB, creating a chain of 4, together capable of driving 32 digits. Since MobiFlight allows up to 8 MAX chips in a single daisy chain, a second module can be connected through the OUT connector (J11). With two boards connected, the daisy chain will consist of all 8 MAX chips, for a total capability of 64 digits.
 
-Since up to 8 MAX chips can be connected in a single daisy chain, this PCB was designed in such a way that a 2nd PCB can be connected easily and another 4 MAX chips are connected. Two boards connected, and the daisy chain is complete with all 8 MAX chips.
+The possible second module can be mounted with M3 spacers on top of the first, or also in a different location if a longer JST-XH cable is used, but longer cables can always pick up more interference from other elecronics, and the MAX7219 are quite sensitive to electrical noise in the signals.
 
-In case of space problems, this 2nd PCB can be mounted in a different location. It couldn't be easier or more comfortable.
+Since an Arduino Mega Module can control up to 4 separate MAX daisy chains, up to 4 x 64, i.e. 256 digits, are possible per Mobiflight board (e.g., [the MEGA Pro Mini](https://shop.mobiflight.com/product/arduino-mega-2560-pro-mini)).
 
-It is therefore still possible to control up to 8 digits per MAX chip and as a daisy chain up to 8 x 8 digits, i.e. 64 digits. Since a Mega Module can control up to 4 separate MAX daisy chains, up to 4 x 64, i.e. 256 digits, are possible per Mobiflight board (e.g., [the MEGA Pro Mini](https://shop.mobiflight.com/product/arduino-mega-2560-pro-mini)).
+The daisy chained chips are laid out in order from top left to bottom right:
+
+```
+1 2
+3 4
+```
 
 ## Connectors
-There are two box headers (straight type) assigned to each MAX chip for more flexibility and efficient use.
+There are two flat cable connectors (straight IDC type) assigned to each MAX chip for more flexibility and efficient use.
 
-![Top View](MAX7219-breakout-board-front.png) 
+![Top View](note-connectors.png) 
+
+The flat cable connectors have a _primary connector_ (PRIM 0-7) and a _secondary connector_ (SEC 4-7) that allows splitting the digits between two digit boards. Please note that the digits are numbered starting from zero, from right to left, like this:
+
+```
+PRIM: 7 6 5 4 3 2 1 0
+SEC:  7 6 5 4
+```
+
+#### A few examples:
 
 Having two connectors allows for the possibility of dividing the 8 digits of a MAX chip between two groups of digts:
 * 2 x 4 digits, 
-* 1 x 3 and 1 x 5 digits,
-* 1 x 6 digits, and 
+* 1 x 3 and 1 x 5 digits (5 on primary, 3 on secondary)
+* 1 x 6 digits (using only primary connector), and 
 * 2 x 3 digits. 
 
 Not all 8 digits of a MAX chip have to be used. Also, the digits do not have to be distributed evenly across the MAX chips.
 
-Between the plugs there are designations such as DIG 0-3, DIG 0-5 and DIG 4-7. This specifies how the digits are to be distributed to the plugs and thus the displays.
+If, for example, 6 digits are plugged into `PRIM 0-7`, digits 0-5 are occupied. This means that digits 6 and 7 on connector J3 would remain unused. The [compatible digit pcb's](https://shop.mobiflight.com/product/max7219-digit-pcb-system-50cm) exist in 3, 4, 5 and 6 digit versions, as those are the most common use cases in most cockpits.
 
-![Top View](note-connectors.png) 
+This applies to connectors next to each of the remaining 3 MAX7129 chips in the same way.
 
-If, for example, 6 digits are plugged into J2, digits 0-5 are occupied. This means that digits 6 and 7 on connector J3 would remain free because, as is well known, there are no 2-digit displays in our cockpits. The smallest display unit would therefore be 3 digits.
-
-This also applies to connectors J4 and J5, J6 and J7 and J8 and J9.
-
-Displays with 3, 4, 5 and 6 digits can be plugged into the connectors J2, J4, J6 and J8. Displays with 3 or 4 digits can be plugged into connectors J3, J5, J7 and J9, but not more than 8 digits in total. A combination of 5 or 6 digits on J2 and 4 digits on J3 at the same time is therefore not possible.
+Displays with 3, 4, 5 and 6 digits can be plugged into the _PRIM (0-7)_ connector. Displays with 3 or 4 digits can be plugged into _SEC (4-7)_ connector, but not more than 8 digits in total. A combination of 5 or 6 digits and 4 digits at the same time is therefore not possible, as the digits would overlap in the middle.
 
 ## Prototyping board
-![External power supply](board-connected-to-prototyping-board.png)
-With the 5-pin XH JST cable that is provided, a connection to the prototyping board is simple.
+![Connecting to Prototyping board](board-connected-to-prototyping-board.png)
+With the 5-pin XH JST cable that is provided, the connection is easy, connect the `7-SEGMENT-1` connector of the Prototyping board to J2 `IN` connector on the MAX7219 breakout board. IF you use a pre-made 5 pin JST-XH cable other than the one that was included with the module, pay attention to the connector orientation, so that the wires connect to the same pins on both connector.
 
 > [!NOTE]
 > Starting with v2.0, the pin sequence is the same for both boards, the prototyping board and the MAX7219 breakout board.
@@ -45,24 +55,21 @@ With the 5-pin XH JST cable that is provided, a connection to the prototyping bo
 You can connect two boards together and take advantage of the daisy chain capability. Two boards is the maximum, only up to 8 MAX7219 chips can be chained. This is a limitation of the MAX7219 chip itself.
 
 ## External Power supply
-The power supply with +5V should be provided via a separate power pack, since a MAX chip can consume between 80 and 120 mA of current and thus the Mega Module or a USB interface (maximum 500 mA with USB 2.x or 900 mA with USB 3 .x) can be overloaded.
+If you chain two modules, or if you encounter problems with the stability of the digits in use, you should first ensure that you are using a direct USB connection to the back of your computer, or via a good quality powered usb hub. Unpowered hubs are sharing the 500mA of the PC usb port with all connected devices, and they are not reliable for connecting MobiFlight boards. A powered hub with guaranteed 500mA per port is needed. If you encounter stability issues in use, and especially if you chain two breakout boards together, you should use external power. Use a good quality, regulated 5V power supply and connect it to the `EXT PWR` connector on the board.
 
 > [!NOTE]
 > When using external power, set the blue jumper to the "EXT" position, otherwise use "INT" position.
-
-
-![External power supply](board-connected-to-prototyping-board.png)
 
 ## Board overview
 ![Top View](MAX7219-breakout-board-front.png) 
 
 ### MAX7219 - IC1-4
-The IC socket and the 4 MAX7219 chips
+The IC socket and the 4 MAX7219 chips, ordered from top left to bottom right.
 
-### Connector - J2-J9
-The connectors to connect the flat ribbon cables
+### Digit module connectors - `PRIM 0-7` and `SEC 4-7`
+The connectors to connect the flat ribbon cables, 2 per MAX chip.
 
-### IN-connectors J1+J11
+### IN-connectors (J2)
 The pins that are connected to pins on the MobiFlight board.
 
 * Pin 1 - VCC
@@ -71,7 +78,7 @@ The pins that are connected to pins on the MobiFlight board.
 * Pin 4 - CS
 * PIN 5 - CLK
 
-### OUT-connectors J10+J12
+### OUT-connector (J11)
 * Pin 1 - VCC
 * Pin 2 - GND
 * Pin 3 - DOUT
@@ -80,11 +87,11 @@ The pins that are connected to pins on the MobiFlight board.
 
 ## Assembly instructions
 1. Solder resistors (10kOhm) to the top of the PCB
-1. Solder the capacitors (100nF) to the top of the PCB
-1. Solder the Max7219 IC sockets to the top of the PCB
-1. Solder the XH JST connectors to the top of the PCB
-1. Solder the 8x2 connectors to the top of the PCB
-1. Insert the MAX7219 Chips into the sockets, watch out for correct orientation
+1. Solder the capacitors (100nF) to the top of the PCB. Be careful, both the resistor (R10k) and the capacitor (C) markings do look fairly simular on the board!
+1. Solder the Max7219 IC sockets to the top of the PCB, make sure the small notch on one end align with the marking on the PCB footprint, so they are oriented correctly.
+1. Solder the XH JST connectors to the top of the PCB, pay attention to the orientation of the cutouts on the connector frame
+1. Solder the 8x2 flat cable connectors to the top of the PCB, also orient the cutout on the connector with the PCB footprint.
+1. Insert the MAX7219 Chips into the sockets, watch out for correct orientation marked by the notch.
 
 ## MobiFlight Configuration
 ### Device configuration


### PR DESCRIPTION
- refer to PRIM and SEC connectors instead of J-numbers as they are not marked on the pcb
- rewrite some of the text to be hopefully more clear.

TODO: instructions to configure digits could still be better.